### PR TITLE
Add support for and test against MSVCC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "include/cxx-prettyprint"]
 	path = include/cxx-prettyprint
-	url = https://github.com/louisdx/cxx-prettyprint.git
+	url = https://github.com/toroidal-code/cxx-prettyprint.git
 [submodule "include/optional"]
 	path = include/optional
 	url = https://github.com/akrzemi1/Optional

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ else ()
   cmake_minimum_required( VERSION 3.0 )
 endif ( IWYU )
 
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror" )
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Werror")
+if ( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Werror")
+endif ()
 
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake")
 include(cotire)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 #C++Spec [![version](https://img.shields.io/badge/version-v0.0.0-blue.svg)]()
-[![Build Status](https://travis-ci.org/toroidal-code/cppspec.svg?branch=master)](https://travis-ci.org/toroidal-code/cppspec)&nbsp; 
+[![Travis](https://img.shields.io/travis/toroidal-code/cppspec/develop.svg)](https://travis-ci.org/toroidal-code/cppspec)&nbsp;
+[![AppVeyor](https://img.shields.io/appveyor/ci/toroidal-code/cppspec.svg?label=msvcc)](https://ci.appveyor.com/project/toroidal-code/cppspec)&nbsp;
 [![GitHub release](https://img.shields.io/github/release/toroidal-code/cppspec.svg)](https://github.com/toroidal-code/cppspec/releases/latest)&nbsp;
-[![Github Releases](https://img.shields.io/github/downloads/toroidal-code/cppspec/latest/total.svg)]()&nbsp; 
+[![Github Releases](https://img.shields.io/github/downloads/toroidal-code/cppspec/latest/total.svg)]()&nbsp;
 [![Documentation Status](https://readthedocs.org/projects/cppspec/badge/?version=latest)](http://cppspec.readthedocs.org/en/latest/?badge=latest)
 
 A behavior-driven development testing library for C++ with an RSpec-inspired DSL.
 
 ## Installation ##
 
-C++Spec is available as a [single collated header-file]( that can be placed in any include path in your project. After that, all features are available via `#include "cppspec.hpp"`.
+C++Spec will be released as a single collated header-file that can be placed in any include path in your project. After that, all features are available via `#include "cppspec.hpp"`.
+
+If you want to use the git repo for development or to integrate it into your own
+project as a submodule, releases will also be available as tags. This project's
+include folder should then be added to your project's include path. Again, all
+functionality is exposed through `#include "cppspec.hpp"`.
 
 ## Documentation ##
 
@@ -28,11 +34,11 @@ If you've ever used RSpec or Jasmine, chances are you'll be familiar with C++Spe
 describe order_spec("Order", $ {
   it("sums the prices of its line items", _ {
     Order order();
-		
+
 	order.add_entry(LineItem().set_item(Item()
 	  .set_price(Money(1.11, Money::USD))
 	));
-	
+
 	order.add_entry(LineItem().set_item(Item()
 	  .set_price(Money(1.11, Money::USD))
 	  .set_quantity(2)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@ os: Visual Studio 2015
 
 platform: x86
 
-configuration: Release
-
 install:
   - git submodule update --init --recursive
 
@@ -14,5 +12,4 @@ build_script:
   - cmake --build .
 
 test_script:
-  - ps: c:\projects\cppspec\spec\spec_runner.exe
-
+  - ps: c:\projects\cppspec\build\spec\Debug\spec_runner.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ platform: x86
 
 configuration: Release
 
+install:
+  - git submodule update --init --recursive
+
 build_script:
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+os: Visual Studio 2015
+
+platform: x86
+
+configuration: Release
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake .. -DBUILD_TESTS=YES
+  - cmake --build .
+
+test_script:
+  - ps: c:\projects\cppspec\spec\spec_runner.exe
+

--- a/include/child.hpp
+++ b/include/child.hpp
@@ -51,7 +51,6 @@ class Child {
   Child &operator=(Child &&) = default;
 
   // Copy constructor/operator
-  Child(const Child &) = default;
   Child &operator=(const Child &) = default;
 
   // Custom constructors

--- a/include/cppspec.hpp
+++ b/include/cppspec.hpp
@@ -12,12 +12,22 @@
 
 /*>>>>>>>>>>>>>>>>>>>> MACROS <<<<<<<<<<<<<<<<<<<<<<*/
 
-#define _ [=](auto &self) mutable
-#define $ [](auto &self)
+// For *some* reason, MSVC++ refuses to correctly deduce the types of
+// Description blocks unless the void return type is explicitly stated.
+// GCC and clang have no problem with it being omitted. Weird.
+#define $ [](auto &self) -> void
+#define _ [=](auto &self) mutable -> void
+
 #define it self.it
+#ifdef _MSC_VER // Apparently MSVC++ doesn't conform to C++14 14.2/4. Annoying.
+#define context self.context
+#define expect self.expect
+#else
 #define context self.template context
-#define explain context  // piggybacks off of the `context` macro
 #define expect self.template expect
+#endif
+#define explain context  // Piggybacks off of the `context` macro
+
 #define is_expected self.is_expected
 #define subject self.subject
 

--- a/include/expectations/expectation.hpp
+++ b/include/expectations/expectation.hpp
@@ -84,14 +84,14 @@ class Expectation : public Child {
       : Child(it), target(std::vector<U>(init_list)) {}
 
   /** @brief Get the target of the expectation. */
-  constexpr const A &get_target() const & { return target; }
-  constexpr A &get_target() & { return target; }
+  const A &get_target() const & { return target; }
+  A &get_target() & { return target; }
 
   /** @brief Get whether the expectation is normal or negated. */
-  constexpr const bool get_sign() const { return is_positive; }
-  constexpr bool get_sign() { return is_positive; }
-  constexpr const bool get_ignore_failure() const { return ignore_failure; }
-  constexpr bool get_ignore_failure() { return ignore_failure; }
+  const bool get_sign() const { return is_positive; }
+  bool get_sign() { return is_positive; }
+  const bool get_ignore_failure() const { return ignore_failure; }
+  bool get_ignore_failure() { return ignore_failure; }
 
   Expectation &not_();
   Expectation &ignore();

--- a/include/formatters/formatters_base.hpp
+++ b/include/formatters/formatters_base.hpp
@@ -2,6 +2,7 @@
 #ifndef CPPSPEC_FORMATTERS_FORMATTERS_BASE
 #define CPPSPEC_FORMATTERS_FORMATTERS_BASE
 #include <iostream>
+#include <string>
 #include "term_colors.hpp"
 
 namespace CppSpec {

--- a/include/result.hpp
+++ b/include/result.hpp
@@ -2,6 +2,7 @@
 #ifndef CPPSPEC_RESULT_HPP
 #define CPPSPEC_RESULT_HPP
 #include <sstream>
+#include <ciso646>
 
 namespace CppSpec {
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -8,8 +8,9 @@
 #ifdef __GNUG__
 #include <cxxabi.h>
 #include <memory>
-#include <sstream>
 #endif
+#include <sstream>
+#include <functional>
 
 namespace CppSpec {
 namespace Util {
@@ -30,7 +31,7 @@ inline std::string demangle(const char *mangled) {
   return (status == 0) ? result.get() : mangled;
 }
 #else
-std::string demangle(const char *name) { return name; }
+inline std::string demangle(const char *name) { return name; }
 #endif
 
 /**
@@ -182,7 +183,7 @@ auto test(void *) -> std::is_function<C>;
 template <class C>
 auto test(int) -> std::is_convertible<C, std::function<void()>>;
 
-template <class>
+template <class C>
 auto test(...) -> std::false_type;  // fallthrough
 }
 


### PR DESCRIPTION
This pull request contains commits that add support for MSVCC 19.0 (Visual Studio 2015) and adds AppVeyor CI integration to test against the Windows platform.

This fixes #3.